### PR TITLE
update notion-source plugin to handle new / deleted nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "gatsby-source-notion": "github:alvis/gatsby-source-notion#pull/2/head",
+    "gatsby-source-notion": "github:alvis/gatsby-source-notion#c97d301",
     "prettier": "^2.2.1"
   },
   "repository": {


### PR DESCRIPTION
Test sur netlify du fix de gatsby-source-notion pour fonctionner avec l'utilisation du cache Gatsby

Si ok, attendre la release officielle du plugin, le mettre à jour, puis clore l'issue après cela.